### PR TITLE
implement support for CO2 sensors sending data unencrypted

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Indoor measuring of Co2 and Temperature
 Especially in office environments employees are sensitive to high levels of Co2 and/or uncomfortably with hot office temperatures.
 This project consists of two parts, the monitor.py and the webinterface.
 
-* **monitor.py** to read the data from the TFA-Dostmann AirControl Mini CO2 sensor and generating the graphs
+* **monitor.py** to read the data from TFA-Dostmann sensors and generating the graphs
 * **webinterface** to display the graphs
 
 **Example Screenshot**
@@ -16,7 +16,10 @@ This project consists of two parts, the monitor.py and the webinterface.
 
 ## hardware
 
-1) [TFA-Dostmann AirControl Mini CO2 Messgerät](http://www.amazon.de/dp/B00TH3OW4Q) -- 80 euro
+1) Multiple CO2 Sensors are supported:
+
+    - [TFA-Dostmann AirControl Mini CO2 Messgerät](http://www.amazon.de/dp/B00TH3OW4Q) -- 65 euro (sends encrypted data)
+    - [TFA-Dostmann AIRCO2NTROL Coach CO2 Monitor](http://www.amazon.de/dp/B07R4XM9Z6) -- 72 euro (sends unencrypted data)
 
 2) [Raspberry PI 2 Model B](http://www.amazon.de/dp/B00T2U7R7I) -- 40 euro
 

--- a/monitor.py
+++ b/monitor.py
@@ -130,9 +130,16 @@ if __name__ == "__main__":
             "RRA:MAX:0.5:12:744",
             "RRA:MAX:0.5:12:61320")
 
+    data_encrypted_print = False
     while True:
         data = list(ord(e) for e in fp.read(8))
-        decrypted = decrypt(key, data)
+        if data[4] == 0x0d and (sum(data[:3]) & 0xff) == data[3]:
+            decrypted = data
+            if data_encrypted_print == False:
+                sys.stderr.write("Info: data not encrypted\n")
+                data_encrypted_print = True
+        else:
+            decrypted = decrypt(key, data)
         if decrypted[4] != 0x0d or (sum(decrypted[:3]) & 0xff) != decrypted[3]:
             print hd(data), " => ", hd(decrypted),  "Checksum error"
         else:


### PR DESCRIPTION
eg. TFA-Dostmann AIRCO2NTROL Coach CO2 Monitor

i just bought https://www.amazon.de/gp/product/B07R4XM9Z6/ and got the following output from `monitor.py`

```
50 03 BA 0D 0D 00 00 00  =>  EB 92 1C 3C 41 D1 E8 3D Checksum error
42 12 A3 F7 0D 00 00 00  =>  A8 B2 1A 7C 43 B1 E8 36 Checksum error
41 0A 22 6D 0D 00 00 00  =>  F8 92 1A 5C 42 B1 E8 49 Checksum error
```

After checking your nice code (thx!) it seem obvious that this sensors is sending data unencrypted :), this PR implements an automatic check if data is encrypted or not and outputs info on the first un-encrypted message.

```
Info: data not encrypted
>>> sending dataset CO2: 1002 TMP: 25.2 ..
>>> sending dataset CO2: 1023 TMP: 25.2 ..
>>> sending dataset CO2: 1048 TMP: 25.2 ..
CO2: 1084 TMP: 25.3
```